### PR TITLE
Automatically enable/disable security if SecurityBundle is here

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -36,7 +36,6 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('api_endpoint')->defaultValue('https://connect.sensiolabs.com/api')->end()
                 ->scalarNode('timeout')->defaultValue(5)->end()
                 ->booleanNode('strict_checks')->defaultValue(true)->end()
-                ->booleanNode('enable_security')->defaultValue(true)->end()
             ->end()
         ;
 

--- a/DependencyInjection/SensioLabsConnectExtension.php
+++ b/DependencyInjection/SensioLabsConnectExtension.php
@@ -11,6 +11,7 @@
 
 namespace SensioLabs\Bundle\ConnectBundle\DependencyInjection;
 
+use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -24,6 +25,13 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
  */
 class SensioLabsConnectExtension extends Extension
 {
+    private $securityEnabled = false;
+
+    public function enableSecurity()
+    {
+        $this->securityEnabled = true;
+    }
+
     public function load(array $configs, ContainerBuilder $container)
     {
         $processor = new Processor();
@@ -31,7 +39,7 @@ class SensioLabsConnectExtension extends Extension
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('connect.xml');
-        if ($config['enable_security']) {
+        if ($this->securityEnabled) {
             $loader->load('security.xml');
         }
 

--- a/SensioLabsConnectBundle.php
+++ b/SensioLabsConnectBundle.php
@@ -27,7 +27,8 @@ class SensioLabsConnectBundle extends Bundle
 {
     public function build(ContainerBuilder $container)
     {
-        if ($container->has('security.authentication.provider.sensiolabs_connect')) {
+        if ($container->hasExtension('security')) {
+            $container->getExtension('sensio_labs_connect')->enableSecurity();
             $container->getExtension('security')->addSecurityListenerFactory(new ConnectFactory());
             $container->getExtension('security')->addUserProviderFactory(new ConnectInMemoryFactory());
         }


### PR DESCRIPTION
Change in #14 doesn't actually work because services are not yet registered in the container, so we can't introspect on it.
Instead, I propose to remove the `enable_security`and automatically introspect in `SecurityExtension` is available during Bundle build and inform our extension that this is the case to allow automatic registration of the required services.

ping @lyrixx @fabpot 