### PR TITLE
Fixed configuration processing

### DIFF
--- a/DependencyInjection/SensioLabsConnectExtension.php
+++ b/DependencyInjection/SensioLabsConnectExtension.php
@@ -12,7 +12,6 @@
 namespace SensioLabs\Bundle\ConnectBundle\DependencyInjection;
 
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
-use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
@@ -34,8 +33,7 @@ class SensioLabsConnectExtension extends Extension
 
     public function load(array $configs, ContainerBuilder $container)
     {
-        $processor = new Processor();
-        $config = $processor->processConfiguration(new Configuration(), $configs);
+        $config = $this->processConfiguration(new Configuration(), $configs);
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('connect.xml');


### PR DESCRIPTION
Not calling the `Extension::processConfiguration()` method prevents tracking env vars correctly, as spotted in symfony/symfony#24020.